### PR TITLE
Remove cupy fix from notebook

### DIFF
--- a/getting_started_tutorials/10min_to_cudf_colab.ipynb
+++ b/getting_started_tutorials/10min_to_cudf_colab.ipynb
@@ -101,55 +101,13 @@
         "id": "43lj_9YlKxx6",
         "outputId": "7b034ca6-8b47-49d2-e3b9-ef38ebf92a3c"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/, https://pypi.ngc.nvidia.com\n",
-            "Requirement already satisfied: cudf-cu11 in /usr/local/lib/python3.8/dist-packages (22.10.0)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (4.1.1)\n",
-            "Requirement already satisfied: cachetools in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (5.2.0)\n",
-            "Collecting cupy-cuda115<12.0.0a0,>=9.5.0\n",
-            "  Using cached cupy_cuda115-10.6.0-cp38-cp38-manylinux1_x86_64.whl (83.3 MB)\n",
-            "Requirement already satisfied: rmm-cu11 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (22.10.0)\n",
-            "Requirement already satisfied: numba>=0.54 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (0.56.4)\n",
-            "Requirement already satisfied: packaging in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (21.3)\n",
-            "Requirement already satisfied: pandas<1.6.0dev0,>=1.0 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (1.3.5)\n",
-            "Requirement already satisfied: cuda-python<11.7.1,>=11.5 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (11.7.0)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (1.21.6)\n",
-            "Requirement already satisfied: protobuf<3.21.0a0,>=3.20.1 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (3.20.3)\n",
-            "Requirement already satisfied: ptxcompiler-cu11 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (0.7.0)\n",
-            "Requirement already satisfied: fsspec>=0.6.0 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (2022.11.0)\n",
-            "Requirement already satisfied: cubinlinker-cu11 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (0.3.0)\n",
-            "Requirement already satisfied: pyarrow==9.0.0 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (9.0.0)\n",
-            "Requirement already satisfied: nvtx>=0.2.1 in /usr/local/lib/python3.8/dist-packages (from cudf-cu11) (0.2.5)\n",
-            "Requirement already satisfied: cython in /usr/local/lib/python3.8/dist-packages (from cuda-python<11.7.1,>=11.5->cudf-cu11) (0.29.32)\n",
-            "Requirement already satisfied: fastrlock>=0.5 in /usr/local/lib/python3.8/dist-packages (from cupy-cuda115<12.0.0a0,>=9.5.0->cudf-cu11) (0.8.1)\n",
-            "Requirement already satisfied: setuptools in /usr/local/lib/python3.8/dist-packages (from numba>=0.54->cudf-cu11) (57.4.0)\n",
-            "Requirement already satisfied: llvmlite<0.40,>=0.39.0dev0 in /usr/local/lib/python3.8/dist-packages (from numba>=0.54->cudf-cu11) (0.39.1)\n",
-            "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.8/dist-packages (from numba>=0.54->cudf-cu11) (4.13.0)\n",
-            "Requirement already satisfied: pytz>=2017.3 in /usr/local/lib/python3.8/dist-packages (from pandas<1.6.0dev0,>=1.0->cudf-cu11) (2022.6)\n",
-            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.8/dist-packages (from pandas<1.6.0dev0,>=1.0->cudf-cu11) (2.8.2)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.8/dist-packages (from python-dateutil>=2.7.3->pandas<1.6.0dev0,>=1.0->cudf-cu11) (1.15.0)\n",
-            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.8/dist-packages (from importlib-metadata->numba>=0.54->cudf-cu11) (3.10.0)\n",
-            "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/lib/python3.8/dist-packages (from packaging->cudf-cu11) (3.0.9)\n",
-            "Installing collected packages: cupy-cuda115\n",
-            "Successfully installed cupy-cuda115-10.6.0\n",
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Collecting cupy-cuda11x\n",
-            "  Using cached cupy_cuda11x-11.3.0-cp38-cp38-manylinux1_x86_64.whl (93.7 MB)\n",
-            "Requirement already satisfied: fastrlock>=0.5 in /usr/local/lib/python3.8/dist-packages (from cupy-cuda11x) (0.8.1)\n",
-            "Requirement already satisfied: numpy<1.26,>=1.20 in /usr/local/lib/python3.8/dist-packages (from cupy-cuda11x) (1.21.6)\n",
-            "Installing collected packages: cupy-cuda11x\n",
-            "Successfully installed cupy-cuda11x-11.3.0\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "!pip install cudf-cu11 --extra-index-url=https://pypi.ngc.nvidia.com\n",
-        "!rm -rf /usr/local/lib/python3.8/dist-packages/cupy*\n",
-        "!pip install cupy-cuda11x"
+        "\n",
+        "#Older documentation included these steps to reintall cupy, but this is no longer necessary since Rapids 22.12\n",
+        "#!rm -rf /usr/local/lib/python3.8/dist-packages/cupy*\n",
+        "#!pip install cupy-cuda11x"
       ]
     },
     {


### PR DESCRIPTION
This comments out and explains the steps previously included to get rapids working that are no longer needed.