### PR TITLE
pin holoviews version to avoid hvplot errors

### DIFF
--- a/getting_started_tutorials/cudf_pandas_opencellid_demo.ipynb
+++ b/getting_started_tutorials/cudf_pandas_opencellid_demo.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "! pip install -q hvplot pydeck panel"
+    "! pip install -q hvplot pydeck panel holoviews=1.18.3"
    ]
   },
   {
@@ -580,7 +580,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This should resolve the hvplot chart errors when working with rapids-24.06:
```
cell 18 - "TypeError: can only concatenate list (not "tuple") to list". 
```
