### PR TITLE
fixes for cudf_pandas_opencellid_demo.ipynb

### DIFF
--- a/getting_started_tutorials/cudf_pandas_opencellid_demo.ipynb
+++ b/getting_started_tutorials/cudf_pandas_opencellid_demo.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "! pip install -q hvplot pydeck panel holoviews=1.18.3"
+    "! pip install -q hvplot pydeck panel holoviews==1.18.3"
    ]
   },
   {

--- a/getting_started_tutorials/cudf_pandas_opencellid_demo.ipynb
+++ b/getting_started_tutorials/cudf_pandas_opencellid_demo.ipynb
@@ -100,8 +100,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# For Google Colab, download the script from a GitHub repository by uncommenting the line below\n",
-    "# !wget https://raw.githubusercontent.com/rapidsai-community/showcase/main/getting_started_tutorials/opencellid_downloader.py"
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "file_name = \"opencellid_downloader.py\"\n",
+    "file_url = f\"https://raw.githubusercontent.com/rapidsai-community/showcase/main/getting_started_tutorials/{file_name}\"\n",
+    "\n",
+    "if os.path.exists(file_name):\n",
+    "    print(f\"The file '{file_name}' exists in the current directory.\")\n",
+    "else:\n",
+    "    print(f\"The file '{file_name}' does not exist in the current directory. Downloading it now...\")\n",
+    "    try:\n",
+    "        subprocess.run([\"wget\", file_url], check=True)\n",
+    "        print(f\"Successfully downloaded '{file_name}'.\")\n",
+    "    except subprocess.CalledProcessError as e:\n",
+    "        print(f\"Failed to download the file. Error: {e}\")\n",
+    "    except FileNotFoundError:\n",
+    "        print(\"The 'wget' command is not found. Please ensure it's installed and in your system PATH.\")"
    ]
   },
   {

--- a/getting_started_tutorials/cudf_pandas_opencellid_demo.ipynb
+++ b/getting_started_tutorials/cudf_pandas_opencellid_demo.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "! pip install -q hvplot pydeck panel holoviews==1.18.3"
+    "! pip install -q hvplot pydeck panel jupyter_bokeh holoviews==1.18.3"
    ]
   },
   {


### PR DESCRIPTION
`! pip install -q hvplot pydeck panel holoviews=1.18.3` gives 
ERROR: Invalid requirement: 'holoviews=1.18.3': Expected end or semicolon (after name and no valid version specifier)
    holoviews=1.18.3
             ^
Hint: = is not a valid operator. Did you mean == ?

![Screenshot 2024-08-29 at 9 57 49 AM](https://github.com/user-attachments/assets/bf973bd5-3750-41c9-a35f-84e6adc5a430)

Added `jupyter_bokeh` in install to avoid 

```
<ipython-input-3-c7cf4cf21953>:7: UserWarning: Using Panel interactively in Colab notebooks requires the jupyter_bokeh package to be installed. Install it with:

    !pip install jupyter_bokeh

and try again.
  pn.extension("deckgl", loading_indicator=True, template='material')
```

![Screenshot 2024-08-29 at 10 10 32 AM](https://github.com/user-attachments/assets/ab08d0c5-4058-40f0-9f32-85b8883431b0)

I also adjusted the part to check if the script exists before downloading


