### PR TITLE
[Showcase] Add Video Notebook: Minimizing Noise Cluster for Topic Modeling

### DIFF
--- a/blogs_notebooks/video_notebook_for_Minimizing_Noise_Cluster_for_Topic_Modeling.ipynb
+++ b/blogs_notebooks/video_notebook_for_Minimizing_Noise_Cluster_for_Topic_Modeling.ipynb
@@ -23,9 +23,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2025-06-16 15:02:22.178] [CUML] [info] cuML: Installed accelerator for sklearn.\n",
+      "[2025-06-16 15:02:23.732] [CUML] [info] cuML: Installed accelerator for umap.\n",
+      "[2025-06-16 15:02:23.736] [CUML] [info] cuML: Installed accelerator for hdbscan.\n",
+      "[2025-06-16 15:02:23.736] [CUML] [info] cuML: Successfully initialized accelerator.\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext cuml.accel"
    ]
@@ -92,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "id": "7rIMmjri5pn0",
     "scrolled": true
@@ -130,42 +141,42 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>-1</td>\n",
-       "      <td>15598</td>\n",
+       "      <td>14801</td>\n",
        "      <td>-1_the_to_and_of</td>\n",
-       "      <td>[the, to, and, of, this, is, it, in, that, br]</td>\n",
-       "      <td>[Heavy-handed moralism. Writers using characte...</td>\n",
+       "      <td>[the, to, and, of, this, is, it, in, that, movie]</td>\n",
+       "      <td>[Now, I have seen a lot of movies in my day, b...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>0</td>\n",
-       "      <td>720</td>\n",
-       "      <td>0_show_series_season_episode</td>\n",
-       "      <td>[show, series, season, episode, episodes, show...</td>\n",
-       "      <td>[I grew up watching Full House as a child. I s...</td>\n",
+       "      <td>873</td>\n",
+       "      <td>0_show_series_episode_episodes</td>\n",
+       "      <td>[show, series, episode, episodes, season, show...</td>\n",
+       "      <td>[\"That '70s Show\" is definitely the funniest s...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>1</td>\n",
-       "      <td>337</td>\n",
-       "      <td>1_bad_movie_worst_this</td>\n",
-       "      <td>[bad, movie, worst, this, you, it, my, acting,...</td>\n",
-       "      <td>[When i got this movie free from my job, along...</td>\n",
+       "      <td>505</td>\n",
+       "      <td>1_japanese_chinese_martial_japan</td>\n",
+       "      <td>[japanese, chinese, martial, japan, arts, acti...</td>\n",
+       "      <td>[Billy Chung Siu Hung's (the bloody swordplay ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>2</td>\n",
-       "      <td>255</td>\n",
-       "      <td>2_bollywood_indian_khan_kapoor</td>\n",
-       "      <td>[bollywood, indian, khan, kapoor, gandhi, amit...</td>\n",
-       "      <td>[I have been waiting for this movie a long tim...</td>\n",
+       "      <td>461</td>\n",
+       "      <td>2_bad_movie_worst_it</td>\n",
+       "      <td>[bad, movie, worst, it, you, this, acting, was...</td>\n",
+       "      <td>[Worst film ever, this is a statement that peo...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>3</td>\n",
-       "      <td>209</td>\n",
-       "      <td>3_funny_jokes_comedy_humor</td>\n",
-       "      <td>[funny, jokes, comedy, humor, laugh, movie, yo...</td>\n",
-       "      <td>[All right, here's the deal: if you're easily ...</td>\n",
+       "      <td>341</td>\n",
+       "      <td>3_horror_scary_movie_movies</td>\n",
+       "      <td>[horror, scary, movie, movies, it, you, house,...</td>\n",
+       "      <td>[(SPOILERS included) This film surely is the b...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -176,94 +187,94 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>311</th>\n",
-       "      <td>310</td>\n",
+       "      <th>299</th>\n",
+       "      <td>298</td>\n",
        "      <td>5</td>\n",
-       "      <td>310_blob_steve_mcqueen_aneta</td>\n",
-       "      <td>[blob, steve, mcqueen, aneta, mcqueens, corsau...</td>\n",
-       "      <td>[The Blob is a classic 1950s B-movie sci-fi fl...</td>\n",
+       "      <td>298_hutton_duchovny_geekboy_muldoon</td>\n",
+       "      <td>[hutton, duchovny, geekboy, muldoon, jolie, jo...</td>\n",
+       "      <td>[Okay, truthfully, I saw the previews for this...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>312</th>\n",
-       "      <td>311</td>\n",
+       "      <th>300</th>\n",
+       "      <td>299</td>\n",
        "      <td>5</td>\n",
-       "      <td>311_woo_scorsese_canon_populism</td>\n",
-       "      <td>[woo, scorsese, canon, populism, directors, el...</td>\n",
-       "      <td>[Another Woo's masterpiece!&lt;br /&gt;&lt;br /&gt;This is...</td>\n",
+       "      <td>299_elephant_elephants_plantation_taylor</td>\n",
+       "      <td>[elephant, elephants, plantation, taylor, finc...</td>\n",
+       "      <td>[A beautiful shopgirl in London is swept off h...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>313</th>\n",
-       "      <td>312</td>\n",
+       "      <th>301</th>\n",
+       "      <td>300</td>\n",
        "      <td>5</td>\n",
-       "      <td>312_roth_rob_weapon_claymore</td>\n",
-       "      <td>[roth, rob, weapon, claymore, roths, marry, sw...</td>\n",
-       "      <td>[THE TEMP (1993) didn't do much theatrical bus...</td>\n",
+       "      <td>300_tomanovich_reverand_dara_mamets</td>\n",
+       "      <td>[tomanovich, reverand, dara, mamets, kirkland,...</td>\n",
+       "      <td>[This centers on unironic notions of coming to...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>314</th>\n",
-       "      <td>313</td>\n",
+       "      <th>302</th>\n",
+       "      <td>301</td>\n",
        "      <td>5</td>\n",
-       "      <td>313_caine_law_pinter_original</td>\n",
-       "      <td>[caine, law, pinter, original, jude, laws, oli...</td>\n",
-       "      <td>[I loved the original. It was brilliant and al...</td>\n",
+       "      <td>301_bombshells_elizabeth_dench_patrick</td>\n",
+       "      <td>[bombshells, elizabeth, dench, patrick, laine,...</td>\n",
+       "      <td>[A charming little film set in the UK about th...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>315</th>\n",
-       "      <td>314</td>\n",
+       "      <th>303</th>\n",
+       "      <td>302</td>\n",
        "      <td>5</td>\n",
-       "      <td>314_gillmore_talking_composition_watched</td>\n",
-       "      <td>[gillmore, talking, composition, watched, wome...</td>\n",
-       "      <td>[I agree with other users comments in that the...</td>\n",
+       "      <td>302_snowy_polynesian_zealand_river</td>\n",
+       "      <td>[snowy, polynesian, zealand, river, pacific, a...</td>\n",
+       "      <td>[Despite the rave reviews this flick has garne...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>316 rows × 5 columns</p>\n",
+       "<p>304 rows × 5 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
        "     Topic  Count                                      Name  \\\n",
-       "0       -1  15598                          -1_the_to_and_of   \n",
-       "1        0    720              0_show_series_season_episode   \n",
-       "2        1    337                    1_bad_movie_worst_this   \n",
-       "3        2    255            2_bollywood_indian_khan_kapoor   \n",
-       "4        3    209                3_funny_jokes_comedy_humor   \n",
+       "0       -1  14801                          -1_the_to_and_of   \n",
+       "1        0    873            0_show_series_episode_episodes   \n",
+       "2        1    505          1_japanese_chinese_martial_japan   \n",
+       "3        2    461                      2_bad_movie_worst_it   \n",
+       "4        3    341               3_horror_scary_movie_movies   \n",
        "..     ...    ...                                       ...   \n",
-       "311    310      5              310_blob_steve_mcqueen_aneta   \n",
-       "312    311      5           311_woo_scorsese_canon_populism   \n",
-       "313    312      5              312_roth_rob_weapon_claymore   \n",
-       "314    313      5             313_caine_law_pinter_original   \n",
-       "315    314      5  314_gillmore_talking_composition_watched   \n",
+       "299    298      5       298_hutton_duchovny_geekboy_muldoon   \n",
+       "300    299      5  299_elephant_elephants_plantation_taylor   \n",
+       "301    300      5       300_tomanovich_reverand_dara_mamets   \n",
+       "302    301      5    301_bombshells_elizabeth_dench_patrick   \n",
+       "303    302      5        302_snowy_polynesian_zealand_river   \n",
        "\n",
        "                                        Representation  \\\n",
-       "0       [the, to, and, of, this, is, it, in, that, br]   \n",
-       "1    [show, series, season, episode, episodes, show...   \n",
-       "2    [bad, movie, worst, this, you, it, my, acting,...   \n",
-       "3    [bollywood, indian, khan, kapoor, gandhi, amit...   \n",
-       "4    [funny, jokes, comedy, humor, laugh, movie, yo...   \n",
+       "0    [the, to, and, of, this, is, it, in, that, movie]   \n",
+       "1    [show, series, episode, episodes, season, show...   \n",
+       "2    [japanese, chinese, martial, japan, arts, acti...   \n",
+       "3    [bad, movie, worst, it, you, this, acting, was...   \n",
+       "4    [horror, scary, movie, movies, it, you, house,...   \n",
        "..                                                 ...   \n",
-       "311  [blob, steve, mcqueen, aneta, mcqueens, corsau...   \n",
-       "312  [woo, scorsese, canon, populism, directors, el...   \n",
-       "313  [roth, rob, weapon, claymore, roths, marry, sw...   \n",
-       "314  [caine, law, pinter, original, jude, laws, oli...   \n",
-       "315  [gillmore, talking, composition, watched, wome...   \n",
+       "299  [hutton, duchovny, geekboy, muldoon, jolie, jo...   \n",
+       "300  [elephant, elephants, plantation, taylor, finc...   \n",
+       "301  [tomanovich, reverand, dara, mamets, kirkland,...   \n",
+       "302  [bombshells, elizabeth, dench, patrick, laine,...   \n",
+       "303  [snowy, polynesian, zealand, river, pacific, a...   \n",
        "\n",
        "                                   Representative_Docs  \n",
-       "0    [Heavy-handed moralism. Writers using characte...  \n",
-       "1    [I grew up watching Full House as a child. I s...  \n",
-       "2    [When i got this movie free from my job, along...  \n",
-       "3    [I have been waiting for this movie a long tim...  \n",
-       "4    [All right, here's the deal: if you're easily ...  \n",
+       "0    [Now, I have seen a lot of movies in my day, b...  \n",
+       "1    [\"That '70s Show\" is definitely the funniest s...  \n",
+       "2    [Billy Chung Siu Hung's (the bloody swordplay ...  \n",
+       "3    [Worst film ever, this is a statement that peo...  \n",
+       "4    [(SPOILERS included) This film surely is the b...  \n",
        "..                                                 ...  \n",
-       "311  [The Blob is a classic 1950s B-movie sci-fi fl...  \n",
-       "312  [Another Woo's masterpiece!<br /><br />This is...  \n",
-       "313  [THE TEMP (1993) didn't do much theatrical bus...  \n",
-       "314  [I loved the original. It was brilliant and al...  \n",
-       "315  [I agree with other users comments in that the...  \n",
+       "299  [Okay, truthfully, I saw the previews for this...  \n",
+       "300  [A beautiful shopgirl in London is swept off h...  \n",
+       "301  [This centers on unironic notions of coming to...  \n",
+       "302  [A charming little film set in the UK about th...  \n",
+       "303  [Despite the rave reviews this flick has garne...  \n",
        "\n",
-       "[316 rows x 5 columns]"
+       "[304 rows x 5 columns]"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -276,16 +287,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "62.39"
+       "59.2"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -317,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
@@ -482,576 +493,576 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:17:21,507] A new study created in memory with name: optuna_bertopic\n"
+      "[I 2025-06-16 14:15:35,127] A new study created in memory with name: optuna_bertopic\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:17:42.409] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:15:51.973] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:17:51,187] Trial 0 finished with value: 0.2585886740893275 and parameters: {'n_components': 19, 'n_neighbors': 13, 'min_dist': 0.6559847055064072, 'min_samples': 22, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 0 with value: 0.2585886740893275.\n"
+      "[I 2025-06-16 14:15:59,898] Trial 0 finished with value: 0.2585886740893275 and parameters: {'n_components': 19, 'n_neighbors': 13, 'min_dist': 0.6559847055064072, 'min_samples': 22, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 0 with value: 0.2585886740893275.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:18:09.609] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:16:16.933] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:18:31,346] Trial 1 finished with value: 0.39012263578060946 and parameters: {'n_components': 11, 'n_neighbors': 17, 'min_dist': 0.7855316209877806, 'min_samples': 8, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 1 with value: 0.39012263578060946.\n"
+      "[I 2025-06-16 14:16:38,791] Trial 1 finished with value: 0.39402694288194373 and parameters: {'n_components': 11, 'n_neighbors': 17, 'min_dist': 0.7855316209877806, 'min_samples': 8, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 1 with value: 0.39402694288194373.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:18:49.425] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:16:55.829] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:19:02,620] Trial 2 finished with value: 0.3288932259110269 and parameters: {'n_components': 14, 'n_neighbors': 11, 'min_dist': 0.9578462739625135, 'min_samples': 22, 'gen_min_span_tree': False, 'prediction_data': True}. Best is trial 1 with value: 0.39012263578060946.\n"
+      "[I 2025-06-16 14:17:04,156] Trial 2 finished with value: 0.22755259693611923 and parameters: {'n_components': 14, 'n_neighbors': 11, 'min_dist': 0.9578462739625135, 'min_samples': 22, 'gen_min_span_tree': False, 'prediction_data': True}. Best is trial 1 with value: 0.39402694288194373.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:19:21.980] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:17:21.286] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:19:30,255] Trial 3 finished with value: 0.2585286740893275 and parameters: {'n_components': 16, 'n_neighbors': 13, 'min_dist': 0.8552674895776905, 'min_samples': 25, 'gen_min_span_tree': False, 'prediction_data': True}. Best is trial 1 with value: 0.39012263578060946.\n"
+      "[I 2025-06-16 14:17:29,947] Trial 3 finished with value: 0.25855867408932753 and parameters: {'n_components': 16, 'n_neighbors': 13, 'min_dist': 0.8552674895776905, 'min_samples': 25, 'gen_min_span_tree': False, 'prediction_data': True}. Best is trial 1 with value: 0.39402694288194373.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:19:47.731] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:17:47.197] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:20:04,996] Trial 4 finished with value: 0.40170523184193907 and parameters: {'n_components': 16, 'n_neighbors': 14, 'min_dist': 0.17615075495259813, 'min_samples': 20, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 4 with value: 0.40170523184193907.\n"
+      "[I 2025-06-16 14:18:03,011] Trial 4 finished with value: 0.3969103338719902 and parameters: {'n_components': 16, 'n_neighbors': 14, 'min_dist': 0.17615075495259813, 'min_samples': 20, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 4 with value: 0.3969103338719902.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:20:22.628] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:18:19.734] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:20:37,928] Trial 5 finished with value: 0.3611193884543922 and parameters: {'n_components': 6, 'n_neighbors': 19, 'min_dist': 0.919979952129186, 'min_samples': 13, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 4 with value: 0.40170523184193907.\n"
+      "[I 2025-06-16 14:18:28,197] Trial 5 finished with value: 0.2586486740893275 and parameters: {'n_components': 6, 'n_neighbors': 19, 'min_dist': 0.919979952129186, 'min_samples': 13, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 4 with value: 0.3969103338719902.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:20:55.775] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:18:44.840] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:21:14,368] Trial 6 finished with value: 0.40234472562585516 and parameters: {'n_components': 18, 'n_neighbors': 11, 'min_dist': 0.5024363814847549, 'min_samples': 14, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 6 with value: 0.40234472562585516.\n"
+      "[I 2025-06-16 14:19:03,844] Trial 6 finished with value: 0.3993301583667193 and parameters: {'n_components': 18, 'n_neighbors': 11, 'min_dist': 0.5024363814847549, 'min_samples': 14, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 6 with value: 0.3993301583667193.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:21:33.004] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:19:21.161] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:21:47,650] Trial 7 finished with value: 0.35322035999115114 and parameters: {'n_components': 11, 'n_neighbors': 8, 'min_dist': 0.537753088603063, 'min_samples': 23, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 6 with value: 0.40234472562585516.\n"
+      "[I 2025-06-16 14:19:35,801] Trial 7 finished with value: 0.3602612607986829 and parameters: {'n_components': 11, 'n_neighbors': 8, 'min_dist': 0.537753088603063, 'min_samples': 23, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 6 with value: 0.3993301583667193.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:22:05.513] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:19:52.978] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:22:24,302] Trial 8 finished with value: 0.41209271366045397 and parameters: {'n_components': 10, 'n_neighbors': 12, 'min_dist': 0.41410321525062666, 'min_samples': 16, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 8 with value: 0.41209271366045397.\n"
+      "[I 2025-06-16 14:20:11,850] Trial 8 finished with value: 0.3958639030397454 and parameters: {'n_components': 10, 'n_neighbors': 12, 'min_dist': 0.41410321525062666, 'min_samples': 16, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 6 with value: 0.3993301583667193.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:22:43.042] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:20:28.364] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:23:01,596] Trial 9 finished with value: 0.412417825504332 and parameters: {'n_components': 8, 'n_neighbors': 13, 'min_dist': 0.35778167444036124, 'min_samples': 13, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 9 with value: 0.412417825504332.\n"
+      "[I 2025-06-16 14:20:47,884] Trial 9 finished with value: 0.41012372293006766 and parameters: {'n_components': 8, 'n_neighbors': 13, 'min_dist': 0.35778167444036124, 'min_samples': 13, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 9 with value: 0.41012372293006766.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:23:20.537] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:21:04.739] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:24:54,081] Trial 10 finished with value: 0.42084292895585484 and parameters: {'n_components': 5, 'n_neighbors': 6, 'min_dist': 0.0856621756325428, 'min_samples': 5, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 10 with value: 0.42084292895585484.\n"
+      "[I 2025-06-16 14:22:34,765] Trial 10 finished with value: 0.4238033112251916 and parameters: {'n_components': 5, 'n_neighbors': 6, 'min_dist': 0.0856621756325428, 'min_samples': 5, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 10 with value: 0.4238033112251916.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:25:11.794] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:22:51.603] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:26:49,788] Trial 11 finished with value: 0.42243183353287117 and parameters: {'n_components': 5, 'n_neighbors': 5, 'min_dist': 0.006038095781139979, 'min_samples': 5, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 11 with value: 0.42243183353287117.\n"
+      "[I 2025-06-16 14:24:25,417] Trial 11 finished with value: 0.43095635637979335 and parameters: {'n_components': 5, 'n_neighbors': 5, 'min_dist': 0.006038095781139979, 'min_samples': 5, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 11 with value: 0.43095635637979335.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:27:07.663] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:24:42.079] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:28:59,935] Trial 12 finished with value: 0.4294117630308482 and parameters: {'n_components': 5, 'n_neighbors': 5, 'min_dist': 0.0231801885461784, 'min_samples': 5, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 12 with value: 0.4294117630308482.\n"
+      "[I 2025-06-16 14:26:17,592] Trial 12 finished with value: 0.42267679278847486 and parameters: {'n_components': 5, 'n_neighbors': 5, 'min_dist': 0.0231801885461784, 'min_samples': 5, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 11 with value: 0.43095635637979335.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:29:17.717] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:26:34.922] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:29:58,795] Trial 13 finished with value: 0.437020570402874 and parameters: {'n_components': 7, 'n_neighbors': 5, 'min_dist': 0.002838319663600081, 'min_samples': 8, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:27:15,937] Trial 13 finished with value: 0.42899552852255635 and parameters: {'n_components': 7, 'n_neighbors': 5, 'min_dist': 0.005350668686725374, 'min_samples': 8, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 11 with value: 0.43095635637979335.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:30:16.818] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:27:32.818] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:30:49,280] Trial 14 finished with value: 0.41792975064661075 and parameters: {'n_components': 8, 'n_neighbors': 8, 'min_dist': 0.23519135017479656, 'min_samples': 9, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:28:04,631] Trial 14 finished with value: 0.41762493357797337 and parameters: {'n_components': 8, 'n_neighbors': 8, 'min_dist': 0.22660613306919541, 'min_samples': 9, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 11 with value: 0.43095635637979335.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:31:07.194] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:28:21.660] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:31:39,725] Trial 15 finished with value: 0.4183153077146528 and parameters: {'n_components': 8, 'n_neighbors': 8, 'min_dist': 0.23794838054739745, 'min_samples': 9, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:28:57,256] Trial 15 finished with value: 0.4160984707849811 and parameters: {'n_components': 8, 'n_neighbors': 8, 'min_dist': 0.239794161607893, 'min_samples': 9, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 11 with value: 0.43095635637979335.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:31:57.264] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:29:14.197] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:33:03,982] Trial 16 finished with value: 0.43302901711599073 and parameters: {'n_components': 7, 'n_neighbors': 5, 'min_dist': 0.0012093750456446985, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:30:23,834] Trial 16 finished with value: 0.4339047428924338 and parameters: {'n_components': 7, 'n_neighbors': 5, 'min_dist': 0.0012105087172698276, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 16 with value: 0.4339047428924338.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:33:22.171] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:30:40.854] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:33:52,611] Trial 17 finished with value: 0.42729516186259453 and parameters: {'n_components': 13, 'n_neighbors': 7, 'min_dist': 0.11928553834143374, 'min_samples': 11, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:31:12,040] Trial 17 finished with value: 0.4247040583210651 and parameters: {'n_components': 10, 'n_neighbors': 7, 'min_dist': 0.11928553834143374, 'min_samples': 11, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 16 with value: 0.4339047428924338.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:34:11.287] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:31:28.990] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:34:29,074] Trial 18 finished with value: 0.4052125282471183 and parameters: {'n_components': 7, 'n_neighbors': 10, 'min_dist': 0.3611662084862251, 'min_samples': 17, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:31:47,305] Trial 18 finished with value: 0.4111306368703605 and parameters: {'n_components': 13, 'n_neighbors': 10, 'min_dist': 0.28222095137931086, 'min_samples': 17, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 16 with value: 0.4339047428924338.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:34:48.983] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:32:04.357] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:35:15,338] Trial 19 finished with value: 0.41727981097628386 and parameters: {'n_components': 10, 'n_neighbors': 16, 'min_dist': 0.286513108944869, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:32:34,649] Trial 19 finished with value: 0.39295782217238157 and parameters: {'n_components': 5, 'n_neighbors': 16, 'min_dist': 0.34485406140919583, 'min_samples': 6, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 16 with value: 0.4339047428924338.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:35:32.850] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:32:51.869] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:35:59,609] Trial 20 finished with value: 0.42301513636520843 and parameters: {'n_components': 9, 'n_neighbors': 9, 'min_dist': 0.11614095187671158, 'min_samples': 11, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:33:18,625] Trial 20 finished with value: 0.4281653736607506 and parameters: {'n_components': 7, 'n_neighbors': 9, 'min_dist': 0.11614095187671158, 'min_samples': 11, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 16 with value: 0.4339047428924338.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:36:17.446] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:33:35.574] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:37:40,421] Trial 21 finished with value: 0.4304642385846754 and parameters: {'n_components': 6, 'n_neighbors': 5, 'min_dist': 0.006053230377275454, 'min_samples': 6, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:34:38,016] Trial 21 finished with value: 0.4300780064867389 and parameters: {'n_components': 7, 'n_neighbors': 5, 'min_dist': 0.006053230377275454, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 16 with value: 0.4339047428924338.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:37:58.070] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:34:55.079] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:39:01,275] Trial 22 finished with value: 0.42480040951944364 and parameters: {'n_components': 7, 'n_neighbors': 6, 'min_dist': 0.002161207201103311, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:35:54,447] Trial 22 finished with value: 0.43720227759735714 and parameters: {'n_components': 9, 'n_neighbors': 6, 'min_dist': 0.0021612169364261147, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:39:29.082] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:36:11.938] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:40:14,590] Trial 23 finished with value: 0.41800879985520495 and parameters: {'n_components': 7, 'n_neighbors': 5, 'min_dist': 0.1523365394465225, 'min_samples': 10, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:36:44,094] Trial 23 finished with value: 0.4203556793466974 and parameters: {'n_components': 9, 'n_neighbors': 7, 'min_dist': 0.1491895612932953, 'min_samples': 10, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:40:38.448] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:37:01.313] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:41:18,494] Trial 24 finished with value: 0.4325692323745668 and parameters: {'n_components': 6, 'n_neighbors': 7, 'min_dist': 0.07274870882252234, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:38:00,677] Trial 24 finished with value: 0.42857334374774014 and parameters: {'n_components': 6, 'n_neighbors': 6, 'min_dist': 0.07274897583375675, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:41:36.000] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:38:17.440] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:42:05,968] Trial 25 finished with value: 0.4285683256703268 and parameters: {'n_components': 9, 'n_neighbors': 7, 'min_dist': 0.08822318066306352, 'min_samples': 11, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:39:36,718] Trial 25 finished with value: 0.41297708499067276 and parameters: {'n_components': 9, 'n_neighbors': 6, 'min_dist': 0.19056897574329767, 'min_samples': 5, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:42:23.712] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:39:53.308] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:43:02,090] Trial 26 finished with value: 0.4177232579190582 and parameters: {'n_components': 12, 'n_neighbors': 7, 'min_dist': 0.21094947576861, 'min_samples': 8, 'gen_min_span_tree': False, 'prediction_data': True}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:40:36,657] Trial 26 finished with value: 0.42831085772894417 and parameters: {'n_components': 12, 'n_neighbors': 9, 'min_dist': 0.06959809405442266, 'min_samples': 7, 'gen_min_span_tree': False, 'prediction_data': True}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:43:19.622] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:40:53.260] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:43:38,485] Trial 27 finished with value: 0.40257465534015574 and parameters: {'n_components': 6, 'n_neighbors': 6, 'min_dist': 0.28458375701470495, 'min_samples': 18, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:41:18,716] Trial 27 finished with value: 0.41787947335202097 and parameters: {'n_components': 6, 'n_neighbors': 7, 'min_dist': 0.28458375701470495, 'min_samples': 11, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:44:08.419] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:41:35.895] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:44:54,414] Trial 28 finished with value: 0.4306313979490242 and parameters: {'n_components': 9, 'n_neighbors': 9, 'min_dist': 0.07113446694417014, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:42:15,635] Trial 28 finished with value: 0.41107165824176783 and parameters: {'n_components': 10, 'n_neighbors': 5, 'min_dist': 0.5722102382508596, 'min_samples': 6, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:45:11.889] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:42:33.077] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:45:38,841] Trial 29 finished with value: 0.4187712267884986 and parameters: {'n_components': 20, 'n_neighbors': 9, 'min_dist': 0.16975846224924285, 'min_samples': 12, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:42:50,741] Trial 29 finished with value: 0.3996944601873649 and parameters: {'n_components': 20, 'n_neighbors': 9, 'min_dist': 0.4253684658245429, 'min_samples': 18, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:45:57.044] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:43:08.082] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:46:05,584] Trial 30 finished with value: 0.25855867408932753 and parameters: {'n_components': 7, 'n_neighbors': 15, 'min_dist': 0.7216519748157755, 'min_samples': 15, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:43:30,133] Trial 30 finished with value: 0.40046380005015 and parameters: {'n_components': 9, 'n_neighbors': 15, 'min_dist': 0.7216519748157755, 'min_samples': 9, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:46:22.920] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:43:47.421] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:47:08,487] Trial 31 finished with value: 0.42995029413089486 and parameters: {'n_components': 9, 'n_neighbors': 9, 'min_dist': 0.08667259709297659, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:44:50,470] Trial 31 finished with value: 0.4299196363726815 and parameters: {'n_components': 7, 'n_neighbors': 5, 'min_dist': 0.0023900101400661407, 'min_samples': 7, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:47:26.343] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:45:07.851] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:48:09,645] Trial 32 finished with value: 0.42877178748976397 and parameters: {'n_components': 10, 'n_neighbors': 7, 'min_dist': 0.08496438222960478, 'min_samples': 9, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:45:53,153] Trial 32 finished with value: 0.42942273187676866 and parameters: {'n_components': 7, 'n_neighbors': 6, 'min_dist': 0.03237838187232781, 'min_samples': 8, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:48:28.720] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:46:10.597] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:49:13,945] Trial 33 finished with value: 0.4254282775637586 and parameters: {'n_components': 6, 'n_neighbors': 6, 'min_dist': 0.049695704297729126, 'min_samples': 8, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:47:29,096] Trial 33 finished with value: 0.41870547975942163 and parameters: {'n_components': 6, 'n_neighbors': 5, 'min_dist': 0.14844782847265728, 'min_samples': 6, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:49:31.709] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:47:46.196] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:50:10,183] Trial 34 finished with value: 0.39651539807833563 and parameters: {'n_components': 8, 'n_neighbors': 10, 'min_dist': 0.5654247210184258, 'min_samples': 6, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:48:29,469] Trial 34 finished with value: 0.4283902675174767 and parameters: {'n_components': 5, 'n_neighbors': 7, 'min_dist': 0.06959943207016685, 'min_samples': 8, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:50:39.376] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:48:46.566] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:51:58,482] Trial 35 finished with value: 0.4145649486068448 and parameters: {'n_components': 11, 'n_neighbors': 6, 'min_dist': 0.1758338436197533, 'min_samples': 6, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:49:06,952] Trial 35 finished with value: 0.4000443955721958 and parameters: {'n_components': 8, 'n_neighbors': 19, 'min_dist': 0.19589947603322433, 'min_samples': 10, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:52:15.973] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:49:23.979] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:52:36,199] Trial 36 finished with value: 0.4016067309539492 and parameters: {'n_components': 14, 'n_neighbors': 19, 'min_dist': 0.05634060490956215, 'min_samples': 10, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:50:55,418] Trial 36 finished with value: 0.4177026289782734 and parameters: {'n_components': 14, 'n_neighbors': 6, 'min_dist': 0.05706027163931862, 'min_samples': 5, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 22 with value: 0.43720227759735714.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:52:54.029] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:51:12.336] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:53:30,853] Trial 37 finished with value: 0.4170922840637984 and parameters: {'n_components': 6, 'n_neighbors': 11, 'min_dist': 0.13822040577690073, 'min_samples': 8, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:51:36,240] Trial 37 finished with value: 0.4399132307553768 and parameters: {'n_components': 11, 'n_neighbors': 10, 'min_dist': 0.0021227884589070994, 'min_samples': 12, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 37 with value: 0.4399132307553768.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:53:48.667] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:51:53.287] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:54:11,820] Trial 38 finished with value: 0.39700528679474667 and parameters: {'n_components': 9, 'n_neighbors': 8, 'min_dist': 0.9933851754076809, 'min_samples': 10, 'gen_min_span_tree': True, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:52:17,096] Trial 38 finished with value: 0.4199464121730489 and parameters: {'n_components': 12, 'n_neighbors': 11, 'min_dist': 0.12133431022641758, 'min_samples': 12, 'gen_min_span_tree': True, 'prediction_data': True}. Best is trial 37 with value: 0.4399132307553768.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-04-09 16:54:29.604] [CUML] [info] Building knn graph using brute force\n"
+      "[2025-06-16 14:52:34.502] [CUML] [info] Building knn graph using brute force\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-04-09 16:55:10,865] Trial 39 finished with value: 0.41538373124889466 and parameters: {'n_components': 17, 'n_neighbors': 5, 'min_dist': 0.2889202158014541, 'min_samples': 7, 'gen_min_span_tree': False, 'prediction_data': False}. Best is trial 13 with value: 0.437020570402874.\n"
+      "[I 2025-06-16 14:52:52,877] Trial 39 finished with value: 0.39252737727258014 and parameters: {'n_components': 11, 'n_neighbors': 10, 'min_dist': 0.8433903744638245, 'min_samples': 15, 'gen_min_span_tree': False, 'prediction_data': True}. Best is trial 37 with value: 0.4399132307553768.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Best params: {'n_components': 7, 'n_neighbors': 5, 'min_dist': 0.002838319663600081, 'min_samples': 8, 'gen_min_span_tree': True, 'prediction_data': False}\n",
-      "CPU times: user 57min 10s, sys: 3min 7s, total: 1h 17s\n",
-      "Wall time: 37min 49s\n"
+      "Best params: {'n_components': 11, 'n_neighbors': 10, 'min_dist': 0.0021227884589070994, 'min_samples': 12, 'gen_min_span_tree': True, 'prediction_data': True}\n",
+      "CPU times: user 54min 41s, sys: 3min, total: 57min 41s\n",
+      "Wall time: 37min 17s\n"
      ]
     }
    ],
@@ -1078,7 +1089,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1128,9 +1139,179 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Topic</th>\n",
+       "      <th>Count</th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Representation</th>\n",
+       "      <th>Representative_Docs</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>-1</td>\n",
+       "      <td>10007</td>\n",
+       "      <td>-1_this_it_movie_was</td>\n",
+       "      <td>[this, it, movie, was, to, the, br, that, and,...</td>\n",
+       "      <td>[Firstly, I really enjoyed this movie and its ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>377</td>\n",
+       "      <td>0_horror_scarecrow_gore_scary</td>\n",
+       "      <td>[horror, scarecrow, gore, scary, scarecrows, g...</td>\n",
+       "      <td>[Scarecrows is one of those films that, with a...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>360</td>\n",
+       "      <td>1_bollywood_indian_kapoor_akshay</td>\n",
+       "      <td>[bollywood, indian, kapoor, akshay, khan, indi...</td>\n",
+       "      <td>[Do not waste your time with this movie. This ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2</td>\n",
+       "      <td>204</td>\n",
+       "      <td>2_french_paris_alexandre_la</td>\n",
+       "      <td>[french, paris, alexandre, la, love, je, taime...</td>\n",
+       "      <td>[I saw \"Paris Je T'Aime\" because a friend real...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>3</td>\n",
+       "      <td>198</td>\n",
+       "      <td>3_martial_jackie_kung_arts</td>\n",
+       "      <td>[martial, jackie, kung, arts, fu, chan, action...</td>\n",
+       "      <td>[Jackie Chan's classic directorial feature POL...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>602</th>\n",
+       "      <td>601</td>\n",
+       "      <td>5</td>\n",
+       "      <td>601_show_smart_butterflies_jokes</td>\n",
+       "      <td>[show, smart, butterflies, jokes, jackass, rea...</td>\n",
+       "      <td>[I understand the jokes quite well, they just ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>603</th>\n",
+       "      <td>602</td>\n",
+       "      <td>5</td>\n",
+       "      <td>602_powell_vance_powells_philo</td>\n",
+       "      <td>[powell, vance, powells, philo, astor, thin, a...</td>\n",
+       "      <td>[I've seen the Thin Man series -- Powell and L...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>604</th>\n",
+       "      <td>603</td>\n",
+       "      <td>5</td>\n",
+       "      <td>603_suleiman_anansa_amin_linderby</td>\n",
+       "      <td>[suleiman, anansa, amin, linderby, arab, caine...</td>\n",
+       "      <td>[The story at the outset is interesting: slave...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>605</th>\n",
+       "      <td>604</td>\n",
+       "      <td>5</td>\n",
+       "      <td>604_coulier_host_hosts_mustve</td>\n",
+       "      <td>[coulier, host, hosts, mustve, kinnear, greg, ...</td>\n",
+       "      <td>[In my opinion, this is a pretty good celebrit...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>606</th>\n",
+       "      <td>605</td>\n",
+       "      <td>5</td>\n",
+       "      <td>605_doc_docs_savage_bronze</td>\n",
+       "      <td>[doc, docs, savage, bronze, hero, unlikable, e...</td>\n",
+       "      <td>[DOC SAVAGE: THE MAN OF BRONZE (1 outta 5 star...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>607 rows × 5 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     Topic  Count                               Name  \\\n",
+       "0       -1  10007               -1_this_it_movie_was   \n",
+       "1        0    377      0_horror_scarecrow_gore_scary   \n",
+       "2        1    360   1_bollywood_indian_kapoor_akshay   \n",
+       "3        2    204        2_french_paris_alexandre_la   \n",
+       "4        3    198         3_martial_jackie_kung_arts   \n",
+       "..     ...    ...                                ...   \n",
+       "602    601      5   601_show_smart_butterflies_jokes   \n",
+       "603    602      5     602_powell_vance_powells_philo   \n",
+       "604    603      5  603_suleiman_anansa_amin_linderby   \n",
+       "605    604      5      604_coulier_host_hosts_mustve   \n",
+       "606    605      5         605_doc_docs_savage_bronze   \n",
+       "\n",
+       "                                        Representation  \\\n",
+       "0    [this, it, movie, was, to, the, br, that, and,...   \n",
+       "1    [horror, scarecrow, gore, scary, scarecrows, g...   \n",
+       "2    [bollywood, indian, kapoor, akshay, khan, indi...   \n",
+       "3    [french, paris, alexandre, la, love, je, taime...   \n",
+       "4    [martial, jackie, kung, arts, fu, chan, action...   \n",
+       "..                                                 ...   \n",
+       "602  [show, smart, butterflies, jokes, jackass, rea...   \n",
+       "603  [powell, vance, powells, philo, astor, thin, a...   \n",
+       "604  [suleiman, anansa, amin, linderby, arab, caine...   \n",
+       "605  [coulier, host, hosts, mustve, kinnear, greg, ...   \n",
+       "606  [doc, docs, savage, bronze, hero, unlikable, e...   \n",
+       "\n",
+       "                                   Representative_Docs  \n",
+       "0    [Firstly, I really enjoyed this movie and its ...  \n",
+       "1    [Scarecrows is one of those films that, with a...  \n",
+       "2    [Do not waste your time with this movie. This ...  \n",
+       "3    [I saw \"Paris Je T'Aime\" because a friend real...  \n",
+       "4    [Jackie Chan's classic directorial feature POL...  \n",
+       "..                                                 ...  \n",
+       "602  [I understand the jokes quite well, they just ...  \n",
+       "603  [I've seen the Thin Man series -- Powell and L...  \n",
+       "604  [The story at the outset is interesting: slave...  \n",
+       "605  [In my opinion, this is a pretty good celebrit...  \n",
+       "606  [DOC SAVAGE: THE MAN OF BRONZE (1 outta 5 star...  \n",
+       "\n",
+       "[607 rows x 5 columns]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Get the topic keywords\n",
     "topic_info = topic_model.get_topic_info()  # Returns a DataFrame with topic details\n",
@@ -1146,14 +1327,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Coherence Score: 0.6592\n"
+      "Coherence Score: 0.6562\n"
      ]
     }
    ],
@@ -1173,14 +1354,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Diversity Score: 0.7517\n"
+      "Diversity Score: 0.7634\n"
      ]
     }
    ],
@@ -1198,14 +1379,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Noise Percentage: 39.1900\n"
+      "Noise Percentage: 41.2500\n"
      ]
     }
    ],
@@ -1233,23 +1414,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# GPU Accelerated Approach\n",
+    "# GPU Acceleration with NVIDIA cuML\n",
     "\n",
-    "The CPU-based and GPU-accelerated approaches use identical code, with the only difference being the addition of <b> %load_ext cuml.accel </b> at the top of the notebook to enable GPU acceleration with cuML. This simple change can significantly speed up the BERTopic model, even for a single trial."
+    "The CPU-based and GPU-accelerated approaches use identical code, with the only difference being the addition of <b>%load_ext cuml.accel</b> at the top of the notebook to enable GPU acceleration with cuML. This simple modification can significantly accelerate the K-Means and UMAP components of the BERTopic model—even within a single trial. You can try it yourself by running the below code on both CPU and GPU and comparing the execution times side by side."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 18,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-06-16 12:18:52.602] [CUML] [info] build_algo set to brute_force_knn because random_state is given\n",
-      "CPU times: user 52.1 s, sys: 2.53 s, total: 54.6 s\n",
-      "Wall time: 25.8 s\n"
+      "[2025-06-16 15:25:47.289] [CUML] [info] build_algo set to brute_force_knn because random_state is given\n",
+      "CPU times: user 53.7 s, sys: 1.88 s, total: 55.6 s\n",
+      "Wall time: 22.8 s\n"
      ]
     }
    ],


### PR DESCRIPTION
**Summary**
This PR adds a companion notebook for the video "Minimizing Noise for Topic Modeling." The notebook demonstrates how to enhance BERTopic by reducing the proportion of documents assigned to the noise cluster (-1) through hyperparameter optimization (HPO) for an objective function.

**Key Features**

- Implements a weighted objective function that balances:

> - Topic Coherence
> - Topic Diversity
> - Noise Penalty for unusable data

- Uses Optuna for automated HPO of UMAP and HDBSCAN parameters
- Integrates NVIDIA cuML for GPU acceleration via %load_ext cuml.accel
- Achieves significant speedup with zero code change
- Validated on the IMDb reviews dataset

**Notes**

- This notebook is intended for inclusion in the showcase/blogs_notebooks directory.
- It aligns with the structure and content presented in the associated tutorial video.