### PR TITLE
Add SPDX headers and update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 
                                  Apache License
                            Version 2.0, January 2004

--- a/benchmarks/mortgage/utils/utils.py
+++ b/benchmarks/mortgage/utils/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import glob
 import multiprocessing

--- a/event_notebooks/GTC_2021/credit_scorecard/cpu/__init__.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/cpu/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/event_notebooks/GTC_2021/credit_scorecard/cpu/data_utils.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/cpu/data_utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from woesc_utils import *
 
 

--- a/event_notebooks/GTC_2021/credit_scorecard/cpu/woesc_utils.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/cpu/woesc_utils.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # coding: utf-8
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 ## Utility functions for weight of evidence scorecarding
 

--- a/event_notebooks/GTC_2021/credit_scorecard/gpu/__init__.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/gpu/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/event_notebooks/GTC_2021/credit_scorecard/gpu/woesc_utils_gpu.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/gpu/woesc_utils_gpu.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # coding: utf-8
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 # ## Utility functions for weight of evidence scorecarding
 

--- a/event_notebooks/KDD_2020/notebooks/Lungs/rapids_scanpy_funcs.py
+++ b/event_notebooks/KDD_2020/notebooks/Lungs/rapids_scanpy_funcs.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Copyright (c) 2020, NVIDIA CORPORATION.
 #

--- a/event_notebooks/KDD_2020/notebooks/Taxi/nyctaxi_data.py
+++ b/event_notebooks/KDD_2020/notebooks/Taxi/nyctaxi_data.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import sys
 import urllib.request

--- a/event_notebooks/KDD_2020/notebooks/parking/__patch/cuspatial_init_patched.py
+++ b/event_notebooks/KDD_2020/notebooks/parking/__patch/cuspatial_init_patched.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from .core.gis import (
    directed_hausdorff_distance,
     haversine_distance,

--- a/event_notebooks/TMLS_2020/notebooks/Taxi/nyctaxi_data.py
+++ b/event_notebooks/TMLS_2020/notebooks/Taxi/nyctaxi_data.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import sys
 import urllib.request

--- a/getting_started_tutorials/opencellid_downloader.py
+++ b/getting_started_tutorials/opencellid_downloader.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import requests
 import tarfile

--- a/team_contributions/cuxfilter-tutorial/preprocess.py
+++ b/team_contributions/cuxfilter-tutorial/preprocess.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyproj import Proj, Transformer
 
 def transform_coords(df, x='x', y='y'):


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to Python scripts
- update the root LICENSE file with the NVIDIA Apache 2.0 license text

## Notes
- SPDX headers are inserted after shebang and Python encoding declarations where present.