### PR TITLE
Add SPDX headers to shell and C++ files

### DIFF
--- a/benchmarks/mortgage/utils/utils.py
+++ b/benchmarks/mortgage/utils/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/event_notebooks/GTC_2021/credit_scorecard/cpu/__init__.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/cpu/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/event_notebooks/GTC_2021/credit_scorecard/cpu/data_utils.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/cpu/data_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from woesc_utils import *

--- a/event_notebooks/GTC_2021/credit_scorecard/cpu/woesc_utils.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/cpu/woesc_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/event_notebooks/GTC_2021/credit_scorecard/gpu/__init__.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/gpu/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/event_notebooks/GTC_2021/credit_scorecard/gpu/woesc_utils_gpu.py
+++ b/event_notebooks/GTC_2021/credit_scorecard/gpu/woesc_utils_gpu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/event_notebooks/KDD_2020/kdd_initial_setup.sh
+++ b/event_notebooks/KDD_2020/kdd_initial_setup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This script sets up the RAPIDS nightly container for the KDD 2020 hands-on tutorial
 
 echo "****************************************************************"

--- a/event_notebooks/KDD_2020/notebooks/Lungs/rapids_scanpy_funcs.py
+++ b/event_notebooks/KDD_2020/notebooks/Lungs/rapids_scanpy_funcs.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 #

--- a/event_notebooks/KDD_2020/notebooks/Taxi/nyctaxi_data.py
+++ b/event_notebooks/KDD_2020/notebooks/Taxi/nyctaxi_data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/event_notebooks/KDD_2020/notebooks/parking/__patch/cuspatial_init_patched.py
+++ b/event_notebooks/KDD_2020/notebooks/parking/__patch/cuspatial_init_patched.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from .core.gis import (

--- a/event_notebooks/TMLS_2020/notebooks/Taxi/nyctaxi_data.py
+++ b/event_notebooks/TMLS_2020/notebooks/Taxi/nyctaxi_data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/getting_started_tutorials/opencellid_downloader.py
+++ b/getting_started_tutorials/opencellid_downloader.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/team_contributions/cuxfilter-tutorial/preprocess.py
+++ b/team_contributions/cuxfilter-tutorial/preprocess.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyproj import Proj, Transformer


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to shell scripts and C++ files
- preserve shell shebang placement where present
- replace `<year>` with `2026` in existing Python SPDX copyright headers

## Notes
- C++ files use block-comment SPDX headers.
- Shell scripts use `#` SPDX headers so scripts remain valid.